### PR TITLE
Fix library name to resolve compatibility problems

### DIFF
--- a/FirmataClient.h
+++ b/FirmataClient.h
@@ -4,7 +4,7 @@
 #define _FIRMATACLIENT_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
There were a problem with `Arduino.h` library because the import name was wrong.

I fixed it replacing the name with the correct one